### PR TITLE
Add patch for Drupal Core issue #3230541

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,12 @@
         "sort-packages": true
     },
     "extra": {
+        "enable-patching": true,
+        "patches": {
+            "drupal/core": {
+                "3230541: Fix queue items not being leased by cron for proper time segments": "https://git.drupalcode.org/project/drupal/-/commit/2ad24e4525c0a03f444733d26b5af7fc0427fcf9.diff"
+            }
+        },
         "drupal-scaffold": {
             "locations": {
                 "web-root": "docroot/"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "3230541: Fix queue items not being leased by cron for proper time segments": "https://www.drupal.org/files/issues/2021-09-01/3230541-7.patch"
+                "3230541: Fix queue items not being leased by cron for proper time segments": "https://gist.githubusercontent.com/clayliddell/ff3266d1d4efd717fbdca722adbd6a97/raw/cddebc6370dc40b276f9af5e1290c4eca53c0ccc/drupal-3230541-85-93.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "3230541: Fix queue items not being leased by cron for proper time segments": "https://git.drupalcode.org/project/drupal/-/commit/2ad24e4525c0a03f444733d26b5af7fc0427fcf9.diff"
+                "3230541: Fix queue items not being leased by cron for proper time segments": "https://www.drupal.org/files/issues/2021-09-01/3230541-7.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,6 @@
         "installer-types": [
             "bower-asset",
             "npm-asset"
-        ],
-        "enable-patching": true
+        ]
     }
 }


### PR DESCRIPTION
Fixes GetDKAN/dkan#3639

This PR adds a patch to resolve issues in the Drupal Core Cron service.

See [drupal/core#3230541](https://www.drupal.org/project/drupal/issues/3230541) for more details on the cron bug in Drupal Core.
See https://github.com/GetDKAN/dkan/issues/3639 for more details on how the cron bug affects DKAN Core.

## QA Steps

- [ ] Create a vanilla DKAN project using DKAN tools on the `drupal-core-cron-patch` branch.
- [ ] Create a new dataset with a large resource file (>= 100 MB).
- [ ] Run cron using Drush (`drush cron`).
- [ ] Run another instance of cron using Drush (`drush cron`).
- [ ] Wait until both cron jobs have completed.
- [ ] Ensure no duplicate rows were imported into the datastore for the created dataset.