### PR TITLE
Stick to 9.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     },
     "require": {
         "composer/installers": "^1.9",
-        "drupal/core-composer-scaffold": "^9.2",
-        "drupal/core-project-message": "^9.2",
-        "drupal/core-recommended": "^9.2",
+        "drupal/core-composer-scaffold": "~9.2.0",
+        "drupal/core-project-message": "~9.2.0",
+        "drupal/core-recommended": "~9.2.0",
         "cweagans/composer-patches": "^1.7",
         "drush/drush": "^10.1",
         "getdkan/dkan": "^2.0"
     },
     "require-dev": {
-        "drupal/core-dev": "^9.2",
+        "drupal/core-dev": "~9.2.0",
         "getdkan/mock-chain": "^1.3.0",
         "weitzman/drupal-test-traits": "^1.5"
     },


### PR DESCRIPTION
Prevent jumping to 9.3.x, at least for now.