### PR TITLE
Add '/dkan/' to project .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 docroot
 vendor
 /testUsers.json
+/dkan/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-docroot
-vendor
-/testUsers.json
 /dkan/
+/docroot/
+/testUsers.json
+/vendor/


### PR DESCRIPTION
Add the `/dkan/` directory to the project's `.gitignore` file to prevent local DKAN development from being tracked as a part of this project.