### PR TITLE
Explicitly needs pathauto until #3301389

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/core-composer-scaffold": "~9.3.0",
         "drupal/core-project-message": "~9.3.0",
         "drupal/core-recommended": "~9.3.0",
+        "drupal/pathauto": "^1.10",
         "drush/drush": "^10.1",
         "getdkan/dkan": "^2.0"
     },


### PR DESCRIPTION
DKAN requires moderated_content_bulk_publish which in turn requires pathuto. However, moderated_content_bulk_publish only declares the dependency in the info.yaml file, and not in the composer.json file. This means if we use Composer to add dkan, we end up with no pathauto module, and no way to enable dkan.

When this issues is fixed: https://www.drupal.org/project/moderated_content_bulk_publish/issues/3301389

...we can remove this explicit declaration.
