### PR TITLE
Update to Drupal 9.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+.ddev
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     "require": {
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "~9.4.0",
-        "drupal/core-project-message": "~9.4.0",
-        "drupal/core-recommended": "~9.4.0",
+        "drupal/core-composer-scaffold": "~9.5.0",
+        "drupal/core-project-message": "~9.5.0",
+        "drupal/core-recommended": "~9.5.0",
         "drush/drush": "^10.1",
         "getdkan/dkan": "^2.0"
     },
     "require-dev": {
-        "drupal/core-dev": "~9.4.0",
+        "drupal/core-dev": "~9.5.0",
         "getdkan/mock-chain": "^1.3.0",
         "phpspec/prophecy-phpunit": "^2",
-        "weitzman/drupal-test-traits": "^1.5"
+        "weitzman/drupal-test-traits": "^2.0.1"
     },
     "conflict": {
         "drupal/drupal": "*"
@@ -53,7 +53,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "3274931: Allow specifying cron queue item lease time": "https://www.drupal.org/files/issues/2022-05-20/3274931-5.diff"
+                "2893933: claimItem in the database and memory queues does not use expire correctly": "https://www.drupal.org/files/issues/2023-01-10/2893933-drupal-queue-claim-9.5.x-58.patch"
             }
         },
         "drupal-scaffold": {


### PR DESCRIPTION
Updates composer to use Drupal 9.5.x with the new Drupal core patch + 2.x version of weitzman/drupal-test-traits used by the newest version of DKAN (PHP 8.1 compatibility).

Note that I tested creating a new ddev project locally with this composer file and then ran the functional/unit tests.