### PR TITLE
Add osteel/openapi-httpfoundation-testing to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require-dev": {
         "drupal/core-dev": "~10.1.0",
         "getdkan/mock-chain": "^1.3.0",
+        "osteel/openapi-httpfoundation-testing": "<1.0",
         "phpspec/prophecy-phpunit": "^2",
         "weitzman/drupal-test-traits": "^2.0.1"
     },


### PR DESCRIPTION
Use [osteel/openapi-httpfoundation-testing](https://github.com/osteel/openapi-httpfoundation-testing) for OpenAPI validation.